### PR TITLE
Fix #8: Support SSL/TLS connection by adding TLSClient

### DIFF
--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
@@ -57,7 +57,7 @@ TLSClient client;
 
 void setup() {
     //Initialize serial and wait for port to open:
-    Serial.begin(115200);
+    Serial.begin(9600);
 
     while (!Serial) {
         ; // wait for serial port to connect. Needed for native USB port only

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
@@ -20,8 +20,8 @@
 
 #include <LWiFi.h>
 
-char ssid[] = "MediaTek_Labs";      //  your network SSID (name)
-char pass[] = "84149961";  // your network password (use for WPA, or use as key for WEP)
+char ssid[] = "your_ap_ssid";      //  your network SSID (name)
+char pass[] = "your_ap_password";  // your network password (use for WPA, or use as key for WEP)
 int keyIndex = 0;               // your network key Index number (needed only for WEP)
 
 int status = WL_IDLE_STATUS;

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
@@ -1,0 +1,130 @@
+/*
+  Web client
+
+  This sketch connects to a website (http://download.labs.mediatek.com)
+  using LinkIt 7697
+
+  This example is written for a network using WPA encryption. For
+  WEP or WPA, change the Wifi.begin() call accordingly.
+
+  Circuit:
+  * LinkIt 7697
+
+  created 13 July 2010
+  by dlf (Metodo2 srl)
+  modified 31 May 2012
+  by Tom Igoe
+  modified Jan 2017
+  by MediaTek Labs
+*/
+
+#include <LWiFi.h>
+
+char ssid[] = "MediaTek_Labs";      //  your network SSID (name)
+char pass[] = "84149961";  // your network password (use for WPA, or use as key for WEP)
+int keyIndex = 0;               // your network key Index number (needed only for WEP)
+
+int status = WL_IDLE_STATUS;
+char server[] = "www.howsmyssl.com";   // This website checks TLS/SSL capabilities
+
+// This is the root certificate for our host.
+// Different host server may have different root CA.
+static const char rootCA[] = "-----BEGIN CERTIFICATE-----\r\n"
+"MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/\r\n"
+"MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT\r\n"
+"DkRTVCBSb290IENBIFgzMB4XDTAwMDkzMDIxMTIxOVoXDTIxMDkzMDE0MDExNVow\r\n"
+"PzEkMCIGA1UEChMbRGlnaXRhbCBTaWduYXR1cmUgVHJ1c3QgQ28uMRcwFQYDVQQD\r\n"
+"Ew5EU1QgUm9vdCBDQSBYMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB\r\n"
+"AN+v6ZdQCINXtMxiZfaQguzH0yxrMMpb7NnDfcdAwRgUi+DoM3ZJKuM/IUmTrE4O\r\n"
+"rz5Iy2Xu/NMhD2XSKtkyj4zl93ewEnu1lcCJo6m67XMuegwGMoOifooUMM0RoOEq\r\n"
+"OLl5CjH9UL2AZd+3UWODyOKIYepLYYHsUmu5ouJLGiifSKOeDNoJjj4XLh7dIN9b\r\n"
+"xiqKqy69cK3FCxolkHRyxXtqqzTWMIn/5WgTe1QLyNau7Fqckh49ZLOMxt+/yUFw\r\n"
+"7BZy1SbsOFU5Q9D8/RhcQPGX69Wam40dutolucbY38EVAjqr2m7xPi71XAicPNaD\r\n"
+"aeQQmxkqtilX4+U9m5/wAl0CAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNV\r\n"
+"HQ8BAf8EBAMCAQYwHQYDVR0OBBYEFMSnsaR7LHH62+FLkHX/xBVghYkQMA0GCSqG\r\n"
+"SIb3DQEBBQUAA4IBAQCjGiybFwBcqR7uKGY3Or+Dxz9LwwmglSBd49lZRNI+DT69\r\n"
+"ikugdB/OEIKcdBodfpga3csTS7MgROSR6cz8faXbauX+5v3gTt23ADq1cEmv8uXr\r\n"
+"AvHRAosZy5Q6XkjEGB5YGV8eAlrwDPGxrancWYaLbumR9YbK+rlmM6pZW87ipxZz\r\n"
+"R8srzJmwN0jP41ZL9c8PDHIyh8bwRLtTcm1D9SZImlJnt1ir/md2cXjbDaJWFBM5\r\n"
+"JDGFoqgCWjBH4d1QB7wCCZAA62RjYJsWvIjJEubSfZGL+T0yjWW06XyxV3bqxbYo\r\n"
+"Ob8VZRzI9neWagqNdwvYkQsEjgfbKbYK7p2CNTUQ\r\n"
+"-----END CERTIFICATE-----\r\n";
+
+// Initialize the Ethernet client library
+// with the IP address and port of the server
+// that you want to connect to (port 80 is default for HTTP):
+TLSClient client;
+
+void setup() {
+    //Initialize serial and wait for port to open:
+    Serial.begin(115200);
+
+    while (!Serial) {
+        ; // wait for serial port to connect. Needed for native USB port only
+    }
+
+    // attempt to connect to Wifi network:
+    while (status != WL_CONNECTED) {
+        Serial.print("Attempting to connect to SSID: ");
+        Serial.println(ssid);
+        // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+        status = WiFi.begin(ssid, pass);
+        // wait 2 seconds for connection:
+        delay(2000);
+    }
+    Serial.println("Connected to wifi");
+    printWifiStatus();
+
+    Serial.println("\nStarting connection to server...");
+    // We must set root CA before connecting to host
+    // Note that the lenght includes the terminating NULL,
+    // so use sizeof() instead of strlen().
+    client.setRootCA(rootCA, sizeof(rootCA));
+    if (client.connect(server, 443)) {
+        Serial.println("connected to server (GET)");
+        // Make a HTTP request over SSL (HTTPS)
+        client.println("GET https://www.howsmyssl.com/a/check HTTP/1.1");
+        client.println("Host: www.howsmyssl.com");
+        client.println("Accept: */*");
+        client.println("Connection: close");
+        client.println();
+        delay(10);
+    }
+}
+
+void loop() {
+    // if there are incoming bytes available
+    // from the server, read them and print them:
+    while (client.available()) {
+        char c = client.read();
+        Serial.write(c);
+    }
+
+    // if the server's disconnected, stop the client:
+    if (!client.connected()) {
+        Serial.println();
+        Serial.println("disconnecting from server.");
+        client.stop();
+
+        // do nothing forevermore:
+        while (true);
+    }
+}
+
+
+void printWifiStatus() {
+    // print the SSID of the network you're attached to:
+    Serial.print("SSID: ");
+    Serial.println(WiFi.SSID());
+
+    // print your WiFi shield's IP address:
+    IPAddress ip = WiFi.localIP();
+    Serial.print("IP Address: ");
+    Serial.println(ip);
+
+    // print the received signal strength:
+    long rssi = WiFi.RSSI();
+    Serial.print("signal strength (RSSI):");
+    Serial.print(rssi);
+    Serial.println(" dBm");
+}

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/examples/TLSClient/TLSClient.ino
@@ -88,7 +88,7 @@ void setup() {
         client.println("Accept: */*");
         client.println("Connection: close");
         client.println();
-        delay(10);
+        delay(300);
     }
 }
 

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/LWiFi.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/LWiFi.h
@@ -29,6 +29,7 @@ extern "C" {
 #include "IPAddress.h"
 #include "WiFiClient.h"
 #include "WiFiServer.h"
+#include "TLSClient.h"
 
 class WiFiClass
 {

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/LWiFi.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/LWiFi.h
@@ -57,7 +57,7 @@ class WiFiClass
 		 *
 		 * param ssid: Pointer to the SSID string.
 		 */
-		int begin(char* ssid);
+		int begin(const char* ssid);
 
 		/* Start Wifi connection with WEP encryption.
 		 * Configure a key into the device. The key type (WEP-40, WEP-104)
@@ -67,7 +67,7 @@ class WiFiClass
 		 * param key_idx: The key index to set. Valid values are 0-3.
 		 * param key: Key input buffer.
 		 */
-		int begin(char* ssid, uint8_t key_idx, const char* key);
+		int begin(const char* ssid, uint8_t key_idx, const char* key);
 
 		/* Start Wifi connection with passphrase
 		 * the most secure supported mode will be automatically selected
@@ -76,7 +76,7 @@ class WiFiClass
 		 * param passphrase: Passphrase. Valid characters in a passphrase
 		 *        must be between ASCII 32-126 (decimal).
 		 */
-		int begin(char* ssid, const char *passphrase);
+		int begin(const char* ssid, const char *passphrase);
 
 		/* Change Ip configuration settings disabling the dhcp client
 		 *

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.cpp
@@ -1,0 +1,342 @@
+#include <Arduino.h>
+#include "TLSClient.h"
+#include <stdio.h>
+
+extern "C"
+{
+#include "log_dump.h"
+#include "mbedtls/debug.h"
+}
+
+static void debugOutput(void *ctx, int level, const char *file, int line, const char *str)
+{
+    pr_debug("%s:%d - %s\r\n", file, line, str);
+}
+
+int TLSContext::init(const unsigned char* host)
+{
+    // debug log level. 0 means no log.
+    mbedtls_debug_set_threshold(1);
+
+    // context initialization
+    mbedtls_net_init(&net_ctx);
+    mbedtls_ssl_init(&ssl_ctx);
+    mbedtls_ssl_config_init(&ssl_conf);
+    mbedtls_entropy_init(&entropy);
+    mbedtls_x509_crt_init(&cacert);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    
+    // entropy source init.
+    // we pass the host URL/address as a "customization".
+    const char *pers = "https";
+    int seedResult = mbedtls_ctr_drbg_seed(&ctr_drbg,
+                                            mbedtls_entropy_func, 
+                                            &entropy,
+                                            (const unsigned char*)pers,
+                                            strlen(pers));
+    if(0 != seedResult)
+    {
+        pr_debug("mbedtls_ctr_drbg_seed failed with %d", seedResult);
+    }
+    return seedResult;
+}
+
+void TLSContext::free()
+{
+    mbedtls_ssl_close_notify(&ssl_ctx);
+    mbedtls_net_free(&net_ctx);
+    mbedtls_x509_crt_free(&cacert);
+    mbedtls_ssl_free(&ssl_ctx);    
+    mbedtls_ssl_config_free(&ssl_conf);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);         
+}
+
+TLSClient::TLSClient()
+{
+    m_connected = false;
+    m_rootCA = NULL;
+    m_rootCALen = 0;
+}
+
+void TLSClient::setRootCA(const char* rootCA, size_t length)
+{
+    m_rootCA = (uint8_t*)rootCA;
+    m_rootCALen = length;
+}
+
+int TLSClient::connect(IPAddress ip, uint16_t port)
+{
+    // convert IP to string
+    String ipString;
+	for (int i =0; i < 3; i++)
+	{
+		ipString += ip[i];
+		ipString += '.';
+	}
+	ipString += ip[3];
+
+    return connectImpl(ipString.c_str(), port, true);
+}
+
+int TLSClient::connect(const char *host, uint16_t port)
+{
+    return connectImpl(host, port, false);
+}
+
+int TLSClient::connectImpl(const char* host, uint16_t port, bool isIPAddress)
+{
+    int ret = 0;
+
+    // initialize mbedTLS
+    m_cntx.init((const unsigned char*)host);
+
+    // initilaize root CA
+    if(m_rootCA)
+    {
+        ret = mbedtls_x509_crt_parse(&m_cntx.cacert,
+                            (const unsigned char *)m_rootCA,
+                            m_rootCALen);
+        if(0 != ret)
+        {
+            pr_debug("mbedtls_x509_crt_parse failed with %d", ret);
+        }
+    }
+
+    // start connection. We'll set SSL/TLS later.
+    do
+    {
+        char portStr[10] = {0};
+        sprintf(portStr, "%d", port) ;
+        pr_debug("connect to %s:%s", host, portStr);
+
+        ret = mbedtls_net_connect(&m_cntx.net_ctx, host, portStr, MBEDTLS_NET_PROTO_TCP);
+        if(0 != ret)
+        {
+            pr_debug("mbedtls_net_connect failed with %d", ret);
+            switch(ret)
+            {
+            case MBEDTLS_ERR_NET_SOCKET_FAILED:
+                pr_debug("MBEDTLS_ERR_NET_SOCKET_FAILED");
+                break;
+            case MBEDTLS_ERR_NET_UNKNOWN_HOST:
+                pr_debug("MBEDTLS_ERR_NET_UNKNOWN_HOST");
+                break;
+            case MBEDTLS_ERR_NET_CONNECT_FAILED:
+                pr_debug("MBEDTLS_ERR_NET_CONNECT_FAILED");
+                break;
+            }
+            break;
+        }
+
+        ret = mbedtls_ssl_config_defaults(&m_cntx.ssl_conf,
+                                           MBEDTLS_SSL_IS_CLIENT,
+                                           MBEDTLS_SSL_TRANSPORT_STREAM,
+                                           MBEDTLS_SSL_PRESET_DEFAULT);
+        if(0 != ret)
+        {
+            pr_debug("mbedtls_ssl_config_defaults failed with %d", ret);   
+            break;
+        }
+
+        // modify connection profile
+        static mbedtls_x509_crt_profile profile;
+        memcpy(&profile, m_cntx.ssl_conf.cert_profile, sizeof(mbedtls_x509_crt_profile));
+        profile.allowed_mds |= MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_MD5);
+        mbedtls_ssl_conf_cert_profile(&m_cntx.ssl_conf, &profile);
+
+        // configure root CA if present
+        mbedtls_ssl_conf_authmode(&m_cntx.ssl_conf, m_rootCA ? MBEDTLS_SSL_VERIFY_OPTIONAL : MBEDTLS_SSL_VERIFY_NONE);
+        if(m_rootCA){
+            mbedtls_ssl_conf_ca_chain(&m_cntx.ssl_conf, &m_cntx.cacert, NULL);
+        }
+        mbedtls_ssl_conf_rng(&m_cntx.ssl_conf, mbedtls_ctr_drbg_random, &m_cntx.ctr_drbg);
+        mbedtls_ssl_conf_dbg(&m_cntx.ssl_conf, debugOutput, NULL);
+
+        ret = mbedtls_ssl_setup(&m_cntx.ssl_ctx, &m_cntx.ssl_conf);
+        if(0 != ret)
+        {
+            pr_debug("mbedtls_ssl_setup failed with %d", ret);
+            break;
+        }
+
+        // only set hostname if we're connecting to a URL
+        if(!isIPAddress)
+        {
+            if( ( ret = mbedtls_ssl_set_hostname( &m_cntx.ssl_ctx, host) ) != 0 )
+            {
+                pr_debug("mbedtls_ssl_set_hostname returned %d\r\n", ret );
+                break;
+            }
+        }
+
+        mbedtls_ssl_set_bio(&m_cntx.ssl_ctx, &m_cntx.net_ctx, mbedtls_net_send, mbedtls_net_recv, NULL);
+
+        // waiting for handshaking
+        while ((ret = mbedtls_ssl_handshake(&m_cntx.ssl_ctx)) != 0) {
+            if (ret != MBEDTLS_ERR_SSL_WANT_READ && ret != MBEDTLS_ERR_SSL_WANT_WRITE) {      
+                pr_debug("mbedtls_ssl_handshake() failed, ret:-0x%x.", -ret);
+                return 0;
+            }
+        }
+            
+        /*
+        * Verify the server certificate
+        */
+        /* In real life, we would have used MBEDTLS_SSL_VERIFY_REQUIRED so that the
+            * handshake would not succeed if the peer's cert is bad.  Even if we used
+            * MBEDTLS_SSL_VERIFY_OPTIONAL, we would bail out here if ret != 0 */
+        int flags = 0;
+        if ((flags = mbedtls_ssl_get_verify_result(&m_cntx.ssl_ctx)) != 0) {
+            char verificationError[512] = {0};
+            pr_debug("svr_cert varification failed:");
+            mbedtls_x509_crt_verify_info(verificationError, sizeof(verificationError), "  ! ", flags);
+            pr_debug("%s", verificationError);
+        }
+        
+        ret = 0;
+        m_connected = true;
+
+        pr_debug("yeah! connected and verified\r\n");
+
+    }while(false);
+    
+    return (ret==0);
+}
+
+size_t TLSClient::write(uint8_t c)
+{
+    pr_debug("%c", c);
+    return write(&c, 1);
+}
+
+size_t TLSClient::write(const uint8_t *data, size_t length)
+{
+    pr_debug("%s", data);
+
+    size_t written_len = 0;
+
+    while (written_len < length) {
+        int ret = mbedtls_ssl_write(&m_cntx.ssl_ctx, (unsigned char *)(data + written_len), (length - written_len));
+        if (ret > 0) {
+            written_len += ret;
+            continue;
+        } else if (ret == 0) {
+            return written_len;
+        } else {
+            m_connected = false;
+            return 0; /* Connnection error */
+        }
+    }
+
+    return written_len;
+}
+
+int TLSClient::available()
+{
+    int ret = mbedtls_ssl_read( &m_cntx.ssl_ctx, NULL, 0 );
+    
+    if( ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE )
+    {    
+        pr_debug("want read/write\r\n");
+        // this is "normal" - we just need to wait for the data.
+        return 0;
+    }
+
+    if( ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY )
+    {
+        // host closes the connection.
+        pr_debug("peer closed");
+        stop();
+        return 0;
+    }   
+
+    if( ret < 0 )
+    {
+        pr_debug("failed\n  ! mbedtls_ssl_read returned %d\n\n", ret );
+        stop();
+        return 0;
+    }
+
+    int len = mbedtls_ssl_get_bytes_avail(&m_cntx.ssl_ctx);
+    return len;
+}
+
+int TLSClient::read()
+{
+    uint8_t c;
+    if(1 == read(&c, 1))
+    {
+        return c;
+    }
+    else
+    {
+        return -1;
+    }
+}
+
+int TLSClient::read(uint8_t *buf, size_t size)
+{
+    int ret = mbedtls_ssl_read(&m_cntx.ssl_ctx, buf, size);
+    
+    if( ret == MBEDTLS_ERR_SSL_WANT_READ || ret == MBEDTLS_ERR_SSL_WANT_WRITE )
+    {    
+        pr_debug("want read/write\r\n");
+        // this is "normal" - we just need to wait for the data.
+        return 0;
+    }
+
+    if( ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY )
+    {
+        // host closes the connection.
+        pr_debug("peer closed");
+        stop();
+        return -1;
+    }   
+
+    if( ret < 0 )
+    {
+        // mbedTLS error condition
+        pr_debug("failed\n  ! mbedtls_ssl_read returned %d\n\n", ret );
+        stop();
+        return -1;
+    }
+
+    return ret;
+}
+
+int TLSClient::peek()
+{
+    if(!available())
+    {
+        return -1;
+    }
+
+    // TODO: read peak byte from the databuffer
+}
+
+void TLSClient::flush()
+{
+    while(available())
+    {
+        uint8_t buf[256] = {0};
+        read(buf, sizeof(buf));
+    }
+}
+
+void TLSClient::stop()
+{
+    // disconnect
+    m_cntx.free();
+    m_connected = false;
+}
+
+uint8_t TLSClient::connected()
+{
+    return m_connected;
+}
+
+TLSClient::operator bool()
+{
+    return m_connected;
+}

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.cpp
@@ -312,7 +312,8 @@ int TLSClient::peek()
         return -1;
     }
 
-    // TODO: read peak byte from the databuffer
+    // as of now, we don't support peek() in TLSClient.
+    return -1;
 }
 
 void TLSClient::flush()

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.h
@@ -1,0 +1,78 @@
+/*
+  TLSClient.h - Library for LinkIt 7697
+*/
+
+#ifndef wifitlsclient_h
+#define wifitlsclient_h
+
+#include <stdio.h>
+#include "Print.h"
+#include "Client.h"
+#include "IPAddress.h"
+
+extern "C"
+{
+#include "mbedtls/net.h"
+#include "mbedtls/ssl.h"
+#include "mbedtls/certs.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/ctr_drbg.h"
+}
+
+// This class stores context data required for underlying mbedTLS library
+struct TLSContext
+{
+	mbedtls_ssl_context ssl_ctx;        /* mbedtls ssl context */
+	mbedtls_net_context net_ctx;        /* Fill in socket id */
+	mbedtls_ssl_config ssl_conf;        /* SSL configuration */
+	mbedtls_entropy_context entropy;
+	mbedtls_ctr_drbg_context ctr_drbg;
+	mbedtls_x509_crt cacert;
+	// -1 is returned when error happens
+	int init(const unsigned char* host);
+
+	void free();
+};
+
+class TLSClient : public Client {
+public:
+	TLSClient();
+
+	uint8_t status();
+
+	// Set the Root Certificate of the remote host.
+	// Note that length should contain the NULL-terminator
+	// if the CA is in PEM string format.
+	// 
+	// the rootCA buffer must be valid during
+	// connect() - stop().
+	void setRootCA(const char* rootCA, size_t length);
+
+	virtual int connect(IPAddress ip, uint16_t port);
+	virtual int connect(const char *host, uint16_t port);
+	virtual size_t write(uint8_t);
+	virtual size_t write(const uint8_t *buf, size_t size);
+	virtual int available();
+	virtual int read();
+	virtual int read(uint8_t *buf, size_t size);
+	virtual int peek();
+	virtual void flush();
+	virtual void stop();
+	virtual uint8_t connected();
+	virtual operator bool();
+
+	friend class WiFiServer;
+
+	using Print::write;
+
+private:
+	int connectImpl(const char* host, uint16_t port, bool isIPAddress);
+
+private:
+	TLSContext m_cntx;
+	bool m_connected;
+	uint8_t *m_rootCA;
+	size_t m_rootCALen;
+};
+
+#endif

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/TLSClient.h
@@ -38,27 +38,58 @@ class TLSClient : public Client {
 public:
 	TLSClient();
 
-	uint8_t status();
-
 	// Set the Root Certificate of the remote host.
-	// Note that length should contain the NULL-terminator
+	// Note that `length` parameter should contain the NULL-terminator
 	// if the CA is in PEM string format.
 	// 
 	// the rootCA buffer must be valid during
 	// connect() - stop().
+	//
+	// connect() without calling setRootCA() first suppresses
+	// root CA verification - which can be a potential
+	// security risk.
 	void setRootCA(const char* rootCA, size_t length);
 
+	// connects to a remote TLS host on a given port
 	virtual int connect(IPAddress ip, uint16_t port);
+
+	// connects to a remote TLS host on a given port.
+	// host can be a domain name such as "www.mediatek.com"
 	virtual int connect(const char *host, uint16_t port);
+
+	// write a single byte to remote server.
+	// returns actual bytes written.
 	virtual size_t write(uint8_t);
+
+	// write a buffer of size bytes to remote host.
+	// returns actual bytes written.
 	virtual size_t write(const uint8_t *buf, size_t size);
+
+	// returns > 1 when there is something in the read buffer.
+	// returns 0 when there is nothing to read.
 	virtual int available();
+	
+	// read a single byte. -1(0xFFFFFFFF) is returned when there is nothing to read.
 	virtual int read();
+
+	// read at most `size` bytes of content into `buf`. 
+	// returns actual bytes read.
 	virtual int read(uint8_t *buf, size_t size);
+
+	// return the 1st byte from the read buffer - if availalbe.
+	// -1 is returned when there is nothing to read.
 	virtual int peek();
+
+	// discards content currently in the read buffer
 	virtual void flush();
+
+	// disconnects from the remote host
 	virtual void stop();
+
+	// returns true when the TLS socket connection is alive; false otherwise.
 	virtual uint8_t connected();
+
+	// This TLSClient object is evaluated to true when connected().
 	virtual operator bool();
 
 	friend class WiFiServer;
@@ -70,9 +101,10 @@ private:
 
 private:
 	TLSContext m_cntx;
-	bool m_connected;
-	uint8_t *m_rootCA;
-	size_t m_rootCALen;
+	bool m_connected;		// connection state
+	uint8_t *m_rootCA;		// pointer to the CA buffer. The CA Buffer must be valid for the entire life cycle of TLSClient.
+	size_t m_rootCALen;		// length of the CA buffer content. NULL terminators included.
+	uint32_t m_peekByte;	// cache for the peek() API. -1 means the cache is empty.
 };
 
 #endif

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/WiFi.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/WiFi.cpp
@@ -56,7 +56,7 @@ char* WiFiClass::firmwareVersion()
 	return WiFiDrv::getFwVersion();
 }
 
-int WiFiClass::begin(char* ssid)
+int WiFiClass::begin(const char* ssid)
 {
 	uint8_t status = WL_IDLE_STATUS;
 	uint8_t attempts = WL_MAX_ATTEMPT_CONNECTION;	//retry total 10
@@ -76,7 +76,7 @@ int WiFiClass::begin(char* ssid)
 	return status;
 }
 
-int WiFiClass::begin(char* ssid, uint8_t key_idx, const char *key)
+int WiFiClass::begin(const char* ssid, uint8_t key_idx, const char *key)
 {
 	uint8_t status = WL_IDLE_STATUS;
 	uint8_t attempts = WL_MAX_ATTEMPT_CONNECTION;	//retry total 10
@@ -97,7 +97,7 @@ int WiFiClass::begin(char* ssid, uint8_t key_idx, const char *key)
 	return status;
 }
 
-int WiFiClass::begin(char* ssid, const char *passphrase)
+int WiFiClass::begin(const char* ssid, const char *passphrase)
 {
 	uint8_t status = WL_IDLE_STATUS;
 	uint8_t attempts = WL_MAX_ATTEMPT_CONNECTION;	//retry total 10

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/ard_mtk.c
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/ard_mtk.c
@@ -456,7 +456,7 @@ int8_t get_ip_setting(uint8_t *ip, uint8_t *mask, uint8_t *gwip)
 	return 0;
 }
 
-int8_t set_net(char* ssid, uint8_t ssid_len)
+int8_t set_net(const char* ssid, uint8_t ssid_len)
 {
 	if (ssid_len == 0)
 		return WL_FAILURE;
@@ -503,7 +503,7 @@ err:
 	return WL_FAILURE;
 }
 
-int8_t set_key(char *ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, uint8_t len)
+int8_t set_key(const char *ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, uint8_t len)
 {
 	if (ssid_len == 0 || len == 0)
 		return WL_FAILURE;
@@ -569,7 +569,7 @@ err:
 	return WL_FAILURE;
 }
 
-int8_t set_passphrase(char* ssid, uint8_t ssid_len, const char *passphrase, uint8_t len)
+int8_t set_passphrase(const char* ssid, uint8_t ssid_len, const char *passphrase, uint8_t len)
 {
 	if (ssid_len == 0 || len == 0)
 		return WL_FAILURE;

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/ard_mtk.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/ard_mtk.h
@@ -209,7 +209,7 @@ extern "C" {
 	    return >=0: success
 	            <0: failed
 	*/
-	int8_t set_net(char* ssid, uint8_t ssid_len);
+	int8_t set_net(const char* ssid, uint8_t ssid_len);
 
 	/*
 	    WiFiClass::begin()   wifiSetKey
@@ -224,7 +224,7 @@ extern "C" {
 	    return >=0: success
 	            <0: failed
 	*/
-	int8_t set_key(char *ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, uint8_t len);
+	int8_t set_key(const char *ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, uint8_t len);
 
 	/*
 	    WiFiClass::begin()     wifiSetPassphrase
@@ -238,7 +238,7 @@ extern "C" {
 	    return >=0: success
 	            <0: failed
 	*/
-	int8_t set_passphrase(char* ssid, uint8_t ssid_len, const char *passphrase, uint8_t len);
+	int8_t set_passphrase(const char* ssid, uint8_t ssid_len, const char *passphrase, uint8_t len);
 
 	/*
 	    WiFiClass::status()         getConnectionStatus

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/wifi_drv.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/wifi_drv.cpp
@@ -61,18 +61,18 @@ void WiFiDrv::wifiDriverInit()
 	init_pBuf();
 }
 
-int8_t WiFiDrv::wifiSetNetwork(char* ssid, uint8_t ssid_len)
+int8_t WiFiDrv::wifiSetNetwork(const char* ssid, uint8_t ssid_len)
 {
 	return set_net(ssid, ssid_len);
 }
 
-int8_t WiFiDrv::wifiSetPassphrase(char* ssid, uint8_t ssid_len, const char *passphrase, const uint8_t len)
+int8_t WiFiDrv::wifiSetPassphrase(const char* ssid, uint8_t ssid_len, const char *passphrase, const uint8_t len)
 {
 	return set_passphrase(ssid, ssid_len, passphrase, len);
 }
 
 
-int8_t WiFiDrv::wifiSetKey(char* ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, const uint8_t len)
+int8_t WiFiDrv::wifiSetKey(const char* ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, const uint8_t len)
 {
 	return set_key(ssid, ssid_len, key_idx, key, len);
 }

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/wifi_drv.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LWiFi/src/utility/wifi_drv.h
@@ -87,7 +87,7 @@ class WiFiDrv
 		 * param ssid_len: Lenght of ssid string.
 		 * return: WL_SUCCESS or WL_FAILURE
 		 */
-		static int8_t wifiSetNetwork(char* ssid, uint8_t ssid_len);
+		static int8_t wifiSetNetwork(const char* ssid, uint8_t ssid_len);
 
 		/* Start Wifi connection with passphrase
 		 * the most secure supported mode will be automatically selected
@@ -99,7 +99,7 @@ class WiFiDrv
 		 * param len: Lenght of passphrase string.
 		 * return: WL_SUCCESS or WL_FAILURE
 		 */
-		static int8_t wifiSetPassphrase(char* ssid, uint8_t ssid_len, const char *passphrase, const uint8_t len);
+		static int8_t wifiSetPassphrase(const char* ssid, uint8_t ssid_len, const char *passphrase, const uint8_t len);
 
 		/* Start Wifi connection with WEP encryption.
 		 * Configure a key into the device. The key type (WEP-40, WEP-104)
@@ -112,7 +112,7 @@ class WiFiDrv
 		 * param len: Lenght of key string.
 		 * return: WL_SUCCESS or WL_FAILURE
 		 */
-		static int8_t wifiSetKey(char* ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, const uint8_t len);
+		static int8_t wifiSetKey(const char* ssid, uint8_t ssid_len, uint8_t key_idx, const char *key, const uint8_t len);
 
 		/* Set ip configuration disabling dhcp client
 		 *

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
@@ -29,7 +29,7 @@ compiler.warning_flags.all=-Wall -Wdouble-promotion -Wextra -Werror=uninitialize
 # 1.3 Indicate compile flags: FPU flags, HAL flags and Common flags
 # ---------------------
 compiler.fpu_flags=-mlittle-endian -mthumb -mcpu=cortex-m4 -fsingle-precision-constant -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-compiler.hal_flags=-DPRODUCT_VERSION=7697 -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMBEDTLS_CONFIG_FILE="config-mtk-websocket.h" -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE
+compiler.hal_flags=-DPRODUCT_VERSION=7697 -DMTK_BSPEXT_ENABLE -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE -DMBEDTLS_CONFIG_FILE="config-mtk-websocket.h" -DSUPPORT_MBEDTLS -DMTK_MINISUPP_ENABLE -DMTK_WIFI_TGN_VERIFY_ENABLE
 compiler.com_flags=-gdwarf-2 -Os {compiler.warning_flags} -fno-exceptions -ffunction-sections -fdata-sections -fno-builtin -fno-strict-aliasing -fno-common -DPCFG_OS=2 -D_REENT_SMALL
 
 # 2 Define some variables for the following special pattern

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
@@ -29,7 +29,7 @@ compiler.warning_flags.all=-Wall -Wdouble-promotion -Wextra -Werror=uninitialize
 # 1.3 Indicate compile flags: FPU flags, HAL flags and Common flags
 # ---------------------
 compiler.fpu_flags=-mlittle-endian -mthumb -mcpu=cortex-m4 -fsingle-precision-constant -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-compiler.hal_flags=-DPRODUCT_VERSION=7697 -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMBEDTLS_CONFIG_FILE="config-mtk-basic.h" -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE
+compiler.hal_flags=-DPRODUCT_VERSION=7697 -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMBEDTLS_CONFIG_FILE="config-mtk-websocket.h" -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE
 compiler.com_flags=-gdwarf-2 -Os {compiler.warning_flags} -fno-exceptions -ffunction-sections -fdata-sections -fno-builtin -fno-strict-aliasing -fno-common -DPCFG_OS=2 -D_REENT_SMALL
 
 # 2 Define some variables for the following special pattern

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/platform.txt
@@ -29,7 +29,7 @@ compiler.warning_flags.all=-Wall -Wdouble-promotion -Wextra -Werror=uninitialize
 # 1.3 Indicate compile flags: FPU flags, HAL flags and Common flags
 # ---------------------
 compiler.fpu_flags=-mlittle-endian -mthumb -mcpu=cortex-m4 -fsingle-precision-constant -mfpu=fpv4-sp-d16 -mfloat-abi=hard
-compiler.hal_flags=-DPRODUCT_VERSION=7697 -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMBEDTLS_CONFIG_FILE="$(MTK_MBEDTLS_CONFIG_FILE)" -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE
+compiler.hal_flags=-DPRODUCT_VERSION=7697 -DUSE_HAL_DRIVER -DMTK_NVDM_ENABLE -DMTK_DEBUG_LEVEL_INFO -DMTK_DEBUG_LEVEL_WARNING -DMTK_DEBUG_LEVEL_ERROR -DMTK_LWIP_ENABLE -DMBEDTLS_CONFIG_FILE="config-mtk-basic.h" -DMTK_MINISUPP_ENABLE -DMTK_WIFI_API_TEST_CLI_ENABLE -DMTK_WIFI_REPEATER_ENABLE -DMTK_WIFI_WPS_ENABLE
 compiler.com_flags=-gdwarf-2 -Os {compiler.warning_flags} -fno-exceptions -ffunction-sections -fdata-sections -fno-builtin -fno-strict-aliasing -fno-common -DPCFG_OS=2 -D_REENT_SMALL
 
 # 2 Define some variables for the following special pattern

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/variants/linkit_7697/FreeRTOSConfig.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/variants/linkit_7697/FreeRTOSConfig.h
@@ -98,12 +98,9 @@ extern uint32_t SystemCoreClock;
 #define configTICK_RATE_HZ              ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES            ( 20 )
 #define configMINIMAL_STACK_SIZE        ( ( unsigned short ) 256 )
-/*This option is to enable homekit under middleware/MTK/homekit folder. If the MTK_HOMEKIT_ENABLE compile option is defined, the sources and header files under middleware/MTK/homekit/inc be included by middleware/MTK/homekit/MakeFile.*/
-#if defined(MTK_HOMEKIT_ENABLE)
-#define configTOTAL_HEAP_SIZE           ( ( size_t ) ( 140 * 1024 ) )
-#else
-#define configTOTAL_HEAP_SIZE           ( ( size_t ) ( 80 * 1024 ) )
-#endif
+/* Arduino projects relies more on heap size - so we use a larger heap, compare to the "default" of 80KB. */
+#define configTOTAL_HEAP_SIZE           ( ( size_t ) (140  * 1024 ) )
+
 
 #define configMAX_TASK_NAME_LEN         ( 6 )
 #define configUSE_TRACE_FACILITY        1

--- a/project/linkit_7697/apps/arduino/arduino_lib/GCC/feature.mk
+++ b/project/linkit_7697/apps/arduino/arduino_lib/GCC/feature.mk
@@ -8,4 +8,4 @@ MTK_MINISUPP_ENABLE                 = y
 MTK_BT_ENABLE                       = y
 MTK_BLE_ONLY_ENABLE                 = y
 MTK_HTTPCLIENT_SSL_ENABLE			= y
-MTK_MBEDTLS_CONFIG_FILE             = config-mtk-basic.h
+MTK_MBEDTLS_CONFIG_FILE             = config-mtk-websocket.h


### PR DESCRIPTION
We created a TLSClient class that wraps mBedTLS.

 * mbedTLS is already in the `liblinkit.a`
 * Increase FreeRTOS heap size to 120KB
 * Switch the default mbedTLS config file to `config-mtk-websocket.h` which have a larger TLS content buffer.
 * Add example project **TLSClient.ino**
  * Also fixes #12 by adjust the input ssid string to `const char*`