### PR TITLE
Fix BLEClient multiple connect() issue

### DIFF
--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.h
@@ -173,6 +173,7 @@ public:
 
 protected:
 	bool m_registered;
+	bool m_scanning;
 	void init();
 
 };


### PR DESCRIPTION
BLE framework resource leaks when connect() to a non-existent address. The resource needs to be reclaimed by a "cancel connection" API call. LBLECentral may report a non-existent address because it does not clear old scan entries. Most BLE devices change their device address after a period of time, for privacy reasons. Therefore:

 * Modify LBLECentral::scan(). It now clears the existing scanned entries before starting a new scan
 * Properly cancels the LBLEClient::connect() call if timed out

This should fix the underlying resource leak.