### PR TITLE
Support MCS Game Pad Controller

### DIFF
--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/examples/Gamepad/Gamepad.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/examples/Gamepad/Gamepad.ino
@@ -3,20 +3,20 @@
 #include "MCS.h"
 
 // Assign AP ssid / password here
-#define _SSID "your_ssid"
-#define _KEY  "your_password"
+#define _SSID "your_wifi_ap_ssid"
+#define _KEY  "your_wifi_password"
 
 // Assign device id / key of your test device
 MCSDevice mcs("your_device_id", "your_device_key");
 
 // Assign channel id 
-// The test device should have 1 channel
+// The test device should have a channel id "control_gamepad".
 // the first channel should be "Controller" - "GamePad"
-MCSControllerGamePad gamepad("Gamepad");
+MCSControllerGamePad gamepad("control_gamepad");
 
 void setup() {
   // setup Serial output at 9600
-  Serial.begin(38400);
+  Serial.begin(9600);
 
   // setup Wifi connection
   while(WL_CONNECTED != WiFi.status())
@@ -42,25 +42,31 @@ void setup() {
 
   while(!gamepad.valid())
   {
-    Serial.println("read Gamepad value from MCS...");
+    Serial.println("initialize gamepad default value...");
     gamepad.value();    
+    // Note: At this moment we can "read" the values
+    // of the gamepad - but the value is meaningless.
+    // 
+    // The MCS server returns that "last button pressed" 
+    // in this cause - even if the user is not pressing any button
+    // at this moment.
+    // 
+    // We read the values here simply to make the following
+    // process() -> if(gamepad.updated()) check working.
   }
-  Serial.print("done, Gamepad value = ");
-  Serial.println(gamepad.value()); 
 
 }
 
 void loop() {
-  // call process() to allow background processing, add timeout to avoid high cpu usage
-  Serial.print("process(");
-  Serial.print(millis());
-  Serial.println(")");
-  mcs.process(100); //1000?
+  // Note that each process consumes 1 command from MCS server.
+  // The 100 millisecond timeout assumes that the server
+  // won't send command rapidly.
+  mcs.process(100);
 
   // updated flag will be cleared in process(), user must check it after process() call.
   if(gamepad.updated())
   {
-    Serial.print("Gamepad updated, new value = ");
+    Serial.print("Gamepad event arrived, new value = ");
     Serial.println(gamepad.value());
   }
 

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/examples/Gamepad/Gampad.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/examples/Gamepad/Gampad.ino
@@ -1,0 +1,75 @@
+#include <LWiFi.h>
+#include <WiFiClient.h>
+#include "MCS.h"
+
+// Assign AP ssid / password here
+#define _SSID "your_ssid"
+#define _KEY  "your_password"
+
+// Assign device id / key of your test device
+MCSDevice mcs("your_device_id", "your_device_key");
+
+// Assign channel id 
+// The test device should have 1 channel
+// the first channel should be "Controller" - "GamePad"
+MCSControllerGamePad gamepad("Gamepad");
+
+void setup() {
+  // setup Serial output at 9600
+  Serial.begin(38400);
+
+  // setup Wifi connection
+  while(WL_CONNECTED != WiFi.status())
+  {
+    Serial.print("WiFi.begin(");
+    Serial.print(_SSID);
+    Serial.print(",");
+    Serial.print(_KEY);
+    Serial.println(")...");
+    WiFi.begin(_SSID, _KEY);
+  }
+  Serial.println("WiFi connected !!");
+
+  // setup MCS connection
+  mcs.addChannel(gamepad);
+    
+  while(!mcs.connected())
+  {
+    Serial.println("MCS.connect()...");
+    mcs.connect();
+  }
+  Serial.println("MCS connected !!");
+
+  while(!gamepad.valid())
+  {
+    Serial.println("read Gamepad value from MCS...");
+    gamepad.value();    
+  }
+  Serial.print("done, Gamepad value = ");
+  Serial.println(gamepad.value()); 
+
+}
+
+void loop() {
+  // call process() to allow background processing, add timeout to avoid high cpu usage
+  Serial.print("process(");
+  Serial.print(millis());
+  Serial.println(")");
+  mcs.process(100); //1000?
+
+  // updated flag will be cleared in process(), user must check it after process() call.
+  if(gamepad.updated())
+  {
+    Serial.print("Gamepad updated, new value = ");
+    Serial.println(gamepad.value());
+  }
+
+  // check if need to re-connect
+  while(!mcs.connected())
+  {
+    Serial.println("re-connect to MCS...");
+    mcs.connect();
+    if(mcs.connected())
+      Serial.println("MCS connected !!");
+  }
+} 

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.cpp
@@ -21,7 +21,8 @@ class MCSDevice
 ---------------------------------------------------------------------------- */
 
 MCSDevice::MCSDevice(const String& device_id, const String& device_key):
-mServer("api.mediatek.com"),
+mServer("api.mediatek.com"), //michael: make code change to "api.mediatek.cn" if it is in China
+
 mPort(80),
 mDefTimeout(30*1000),
 mId(device_id),
@@ -1011,3 +1012,82 @@ void MCSDisplayPWM::_dispatch(const String& params)
 {
     // do nothing for display channel
 }
+
+//michael
+/* ----------------------------------------------------------------------------
+class MCSControllerGamePad
+---------------------------------------------------------------------------- */
+
+MCSControllerGamePad::MCSControllerGamePad(const String& channel_id):
+MCSDataChannel(channel_id),
+mValue(0)
+{
+}
+
+MCSControllerGamePad::~MCSControllerGamePad()
+{
+     mUp = mDown = mLeft = mRight = mButtonA = mButtonB = 0;
+}
+
+int MCSControllerGamePad::value(void)
+{
+    // retrieve latest data point from server
+    String params;
+
+    _DEBUG_PRINT("MCSControllerGamePad::value="+params);
+
+    if(valid()) {    	
+    	mValue = mUp+(mDown<<1)+(mLeft<<2)+(mRight<<3)+(mButtonA<<4)+(mButtonB<<5);    	
+        return mValue;
+    }
+        
+    if(_getDataPoint(params))
+    {
+        _update(params);
+        return mValue;
+    }
+    
+    return 0;
+}
+
+void MCSControllerGamePad::_dispatch(const String& params)
+{
+    _DEBUG_PRINT("MCSControllerGamePad::_dispatch="+params);
+    
+    if(_update(params))
+        _setUpdated();
+}
+
+bool MCSControllerGamePad::_update(const String& params)
+{
+    _DEBUG_PRINT("MCSControllerGamePad::_update="+params);
+
+    if (params=="up|0")
+    	mUp = 0;
+    else if (params=="up|1")
+    	mUp = 1;
+    else if (params=="down|0")
+    	mDown = 0;
+    else if (params=="down|1")
+    	mDown = 1;
+    else if (params=="left|0")
+    	mLeft = 0;
+    else if (params=="left|1")
+    	mLeft = 1;
+    else if (params=="right|0")
+    	mRight = 0;
+    else if (params=="right|1")
+    	mRight = 1;
+    else if (params=="A|0")
+    	mButtonA = 0;
+    else if (params=="A|1")
+    	mButtonA = 1;
+    else if (params=="B|0")
+    	mButtonB = 0;
+    else if (params=="B|1")
+    	mButtonB = 1;
+
+    _setValid();
+    return true;
+}
+//michael

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.h
@@ -676,5 +676,31 @@ public:
     }
 };
 
+//michael
+class MCSControllerGamePad : public MCSDataChannel
+{
+public:
+    MCSControllerGamePad(const String& channel_id);
+    ~MCSControllerGamePad();
+    void dump(void);
+    int value(void);
+
+protected:
+    // override
+    virtual void _dispatch(const String& params);
+
+private:
+    bool _update(const String& params);
+
+private:
+    int mValue;
+    int mUp;
+    int mDown;
+    int mLeft;
+    int mRight;
+    int mButtonA;
+    int mButtonB;
+};
+//michael
 
 #endif

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/MCS/src/MCS.h
@@ -676,31 +676,67 @@ public:
     }
 };
 
-//michael
-class MCSControllerGamePad : public MCSDataChannel
+/* ------------------------------------------------------------------------ */
+enum MCSGamePadButton{
+    BTN_UP = 1,
+    BTN_DOWN,
+    BTN_LEFT,
+    BTN_RIGHT,
+    BTN_A,
+    BTN_B,
+    BTN_INVALID
+};
+
+enum MCSGamePadButtonEvent{
+    BTN_PRESSED = 1,
+    BTN_RELEASED = 0,
+    BTN_NO_EVENT = -1
+};
+
+struct MCSGamePadValue : public Printable
+{
+    MCSGamePadButton button;           // The button of the update
+    MCSGamePadButtonEvent event;    // The event associated with the button
+
+    MCSGamePadValue():
+        button(BTN_INVALID),
+        event(BTN_NO_EVENT)
+    {
+    }
+
+    bool operator==(const MCSGamePadValue& rhs)const;
+    bool operator!=(const MCSGamePadValue& rhs)const;
+    explicit operator bool()const;
+    bool isValid()const;
+
+    String toString() const;
+    
+    /// Implement Printable interface to support
+    /// ~~~{.cpp}
+    /// Serial.println(MCSGPSValue());
+    /// ~~~
+    virtual size_t printTo(Print& p) const;
+};
+
+String MCSValueToString(const MCSGamePadValue& value);
+
+void MCSStringToValue(const String& params, MCSGamePadValue& value);
+
+class MCSControllerGamePad : public MCSControllerBase<MCSGamePadValue>
 {
 public:
-    MCSControllerGamePad(const String& channel_id);
-    ~MCSControllerGamePad();
-    void dump(void);
-    int value(void);
+    MCSControllerGamePad(const String& channel_id):MCSControllerBase(channel_id){
+    }
 
-protected:
-    // override
-    virtual void _dispatch(const String& params);
+    inline MCSGamePadButton button()
+    {
+        return value().button;
+    }
 
-private:
-    bool _update(const String& params);
-
-private:
-    int mValue;
-    int mUp;
-    int mDown;
-    int mLeft;
-    int mRight;
-    int mButtonA;
-    int mButtonB;
+    inline MCSGamePadButtonEvent event()
+    {
+        return value().event;
+    }
 };
-//michael
 
 #endif


### PR DESCRIPTION
For #32, based on the patch from @michaelchien1972 

A controller subclass `MCSControllerGamePad` has been added. The value it returns are of type `MCSGamePadValue`. User can `Serial.print()` the value directly.