### PR TITLE
Implement LBLEPeripheral::notifyAll for requst #11

### DIFF
--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/examples/Notification/Notification.ino
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/examples/Notification/Notification.ino
@@ -1,0 +1,77 @@
+/*
+  This example configures LinkIt 7697 to act as a simple GATT server with 1 characteristic.
+  The GATT server notifies changes of the characteristic periodically.
+  
+  created Aug 2017
+*/
+#include <LBLE.h>
+#include <LBLEPeriphral.h>
+
+// Define a simple GATT service with only 1 characteristic
+LBLEService counterService("4e38e0c3-ab04-4c5d-b54a-852900379bb3");
+LBLECharacteristicInt counterCharacteristic("4e38e0c4-ab04-4c5d-b54a-852900379bb3", LBLE_READ | LBLE_WRITE);
+
+int blink_status = 0;;
+
+void setup() {
+
+  // Initialize LED pin
+  pinMode(LED_BUILTIN, OUTPUT);
+  blink_status = 0;
+  digitalWrite(LED_BUILTIN, blink_status);
+
+  //Initialize serial and wait for port to open:
+  Serial.begin(115200);
+
+  // Initialize BLE subsystem
+  LBLE.begin();
+  while (!LBLE.ready()) {
+    delay(100);
+  }
+  Serial.println("BLE ready");
+
+  Serial.print("Device Address = [");
+  Serial.print(LBLE.getDeviceAddress());
+  Serial.println("]");
+
+  // configure our advertisement data.
+  // In this case, we simply create an advertisement that represents an
+  // connectable device with a device name
+  LBLEAdvertisementData advertisement;
+  advertisement.configAsConnectableDevice("GATT");
+
+  // Configure our device's Generic Access Profile's device name
+  // Ususally this is the same as the name in the advertisement data.
+  LBLEPeripheral.setName("GATT Test");
+
+  // Add characteristics into counterService
+  counterService.addAttribute(counterCharacteristic);
+
+  // Add service to GATT server (peripheral)
+  LBLEPeripheral.addService(counterService);
+
+  // start the GATT server - it is now 
+  // available to connect
+  LBLEPeripheral.begin();
+
+  // start advertisment
+  LBLEPeripheral.advertise(advertisement);
+}
+
+void loop() {
+  delay(1000);
+  blink_status = !blink_status;
+
+  Serial.print("conected=");
+  Serial.println(LBLEPeripheral.connected());
+
+  if(LBLEPeripheral.connected())
+  {
+    // increment the value
+    const int newValue = counterCharacteristic.getValue() + 1;
+    counterCharacteristic.setValue(newValue);
+
+    // broadcasting value changes to all connected central devices
+    LBLEPeripheral.notifyAll(counterCharacteristic);
+  }
+}

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLE.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLE.h
@@ -9,6 +9,7 @@
 #include <WString.h>
 #include <Printable.h>
 #include <delay.h>
+#include <vector>
 #include <map>
 
 extern "C" {
@@ -175,6 +176,41 @@ public:	// Helper function
 public:
 	bt_addr_t m_addr;
 };
+
+/// This class encapsulates raw buffer operations used by LBLEClient/LBLEPeripheral
+///
+/// When writing or reading GATT attributes, we need to convert
+/// to raw buffers and meaningful data types used by users.
+/// 
+/// This class helps users to convert to these raw buffer
+/// values when reading or writing GATT attributes.
+class LBLEValueBuffer : public std::vector<uint8_t>
+{
+public:
+	/// Default constructor creates an empty buffer.
+	LBLEValueBuffer();
+
+	/// Create a raw buffer from an integer value.
+	LBLEValueBuffer(int intValue);
+
+	/// Create a raw buffer from a float value.
+	LBLEValueBuffer(float floatValue);
+
+	/// Create a raw buffer from a single-byte character value.
+	LBLEValueBuffer(char charValue);
+
+	/// Create a raw buffer from a NULL-terminated string.
+	/// The resulting buffer contains the trailing NULL bytel.
+	LBLEValueBuffer(const String& strValue);
+
+	template<typename T>void shallowInit(T value);
+};
+
+template<typename T>void LBLEValueBuffer::shallowInit(T value)
+{
+    this->resize(sizeof(value), 0);
+    memcpy(&(*this)[0], &value, sizeof(value));
+}
 
 // Interface of an event observer
 class LBLEEventObserver

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.cpp
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.cpp
@@ -1095,37 +1095,3 @@ void _characteristic_event_handler(bt_msg_type_t msg, bt_status_t, void *buff)
                         pNoti->att_rsp->handle);
     }
 }
-
-//////////////////////////////////////////////////////////////////////////
-//  LBLEValueBuffer
-//////////////////////////////////////////////////////////////////////////
-template<typename T>void LBLEValueBuffer::shallowInit(T value)
-{
-    this->resize(sizeof(value));
-    memcpy(&(*this)[0], &value, sizeof(value));
-}
-
-LBLEValueBuffer::LBLEValueBuffer()
-{
-}
-
-LBLEValueBuffer::LBLEValueBuffer(int intValue)
-{
-    shallowInit(intValue);
-}
-
-LBLEValueBuffer::LBLEValueBuffer(float floatValue)
-{
-    shallowInit(floatValue);
-}
-
-LBLEValueBuffer::LBLEValueBuffer(char charValue)
-{
-    shallowInit(charValue);
-}
-
-LBLEValueBuffer::LBLEValueBuffer(const String& strValue)
-{
-    resize(strValue.length() + 1);
-    strValue.getBytes(&(*this)[0], size());
-}

--- a/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.h
+++ b/middleware/third_party/arduino/hardware/arduino/mt7697/libraries/LBLE/src/LBLECentral.h
@@ -6,7 +6,6 @@
 #define LBLECentral_H
 
 #include <inttypes.h>
-#include <vector>
 #include <WString.h>
 #include <LBLE.h>
 #include <map>
@@ -256,35 +255,6 @@ struct LBLEServiceInfo
 	LBLEUuid uuid;
 	uint16_t startHandle;
 	uint16_t endHandle;
-};
-
-/// This class encapsulates raw buffer operations used by LBLEClient
-///
-/// When writing or reading GATT attributes, we need to convert
-/// to raw buffers and meaningful data types used by users.
-/// 
-/// This class helps users to convert to these raw buffer
-/// values when reading or writing GATT attributes.
-class LBLEValueBuffer : public std::vector<uint8_t>
-{
-public:
-	/// Default constructor creates an empty buffer.
-	LBLEValueBuffer();
-
-	/// Create a raw buffer from an integer value.
-	LBLEValueBuffer(int intValue);
-
-	/// Create a raw buffer from a float value.
-	LBLEValueBuffer(float floatValue);
-
-	/// Create a raw buffer from a single-byte character value.
-	LBLEValueBuffer(char charValue);
-
-	/// Create a raw buffer from a NULL-terminated string.
-	/// The resulting buffer contains the trailing NULL bytel.
-	LBLEValueBuffer(const String& strValue);
-
-	template<typename T>void shallowInit(T value);
 };
 
 /// This class allows users to create connections to remote peripheral devices.


### PR DESCRIPTION
 * Add a new method `notifyAll()` that broadcast to all living connections to `LBLEPeripheral`
 * The connection handle is passed down from LBLEPeripheral to the characteristic object
 * Move the definition of `LBLEValueBuffer` from `LBLECentral.h` to `LBLE.h`
 * The object serializes its current value to `LBLEValueBuffer` and then calls parent class helper method `_notify`
 * The value buffer is then passed down to the LinkIt SDK API `bt_gatts_send_charc_value_notification_indication`

Since notification is a fire-and-forget action, we don't wait for client side ACK events.